### PR TITLE
Don't try to migrate the contents of views.

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -59,6 +59,7 @@ func (p *postgreSQLDB) GetSchemaRows() (*sql.Rows, error) {
 				 character_maximum_length
 	FROM   information_schema.columns
 	WHERE  table_schema = 'public'
+	             AND is_updatable = 'YES'
 				 AND table_name NOT IN ('schema_migrations')
 				 AND table_catalog = $1`
 


### PR DESCRIPTION
In Postgresql, views look a lot like tables, and pg2mysql was trying to migrate them. One way to distinguish them is that views are not updatable, so I exclude non-updatable "tables."