### PR TITLE
Adds support to set charset/collation in config.yml

### DIFF
--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -17,6 +17,8 @@ func (c *MigrateCommand) Execute([]string) error {
 		PG2MySQL.Config.MySQL.Password,
 		PG2MySQL.Config.MySQL.Host,
 		PG2MySQL.Config.MySQL.Port,
+		PG2MySQL.Config.MySQL.Charset,
+		PG2MySQL.Config.MySQL.Collation,
 	)
 
 	err := mysql.Open()

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -15,6 +15,8 @@ func (c *ValidateCommand) Execute([]string) error {
 		PG2MySQL.Config.MySQL.Password,
 		PG2MySQL.Config.MySQL.Host,
 		PG2MySQL.Config.MySQL.Port,
+		PG2MySQL.Config.MySQL.Charset,
+		PG2MySQL.Config.MySQL.Collation,
 	)
 
 	err := mysql.Open()

--- a/commands/verify.go
+++ b/commands/verify.go
@@ -15,6 +15,8 @@ func (c *VerifyCommand) Execute([]string) error {
 		PG2MySQL.Config.MySQL.Password,
 		PG2MySQL.Config.MySQL.Host,
 		PG2MySQL.Config.MySQL.Port,
+		PG2MySQL.Config.MySQL.Charset,
+		PG2MySQL.Config.MySQL.Collation,
 	)
 
 	err := mysql.Open()

--- a/config.go
+++ b/config.go
@@ -2,11 +2,13 @@ package pg2mysql
 
 type Config struct {
 	MySQL struct {
-		Database string `yaml:"database"`
-		Username string `yaml:"username"`
-		Password string `yaml:"password"`
-		Host     string `yaml:"host"`
-		Port     int    `yaml:"port"`
+		Database  string `yaml:"database"`
+		Username  string `yaml:"username"`
+		Password  string `yaml:"password"`
+		Host      string `yaml:"host"`
+		Port      int    `yaml:"port"`
+		Charset   string `yaml:"charset"`
+		Collation string `yaml:"collation"`
 	} `yaml:"mysql"`
 
 	PostgreSQL struct {

--- a/mysql.go
+++ b/mysql.go
@@ -13,7 +13,17 @@ func NewMySQLDB(
 	password string,
 	host string,
 	port int,
+	charset string,
+	collation string,
 ) DB {
+	if (charset == "") {
+		charset = "utf8"
+	}
+
+	if (collation == "") {
+		collation = "utf8_general_ci"
+	}
+
 	config := mysql.Config{
 		User:            username,
 		Passwd:          password,
@@ -22,7 +32,8 @@ func NewMySQLDB(
 		Addr:            fmt.Sprintf("%s:%d", host, port),
 		MultiStatements: true,
 		Params: map[string]string{
-			"charset":   "utf8",
+			"charset":   charset,
+			"collation": collation,
 			"parseTime": "True",
 		},
 	}


### PR DESCRIPTION
This allows us to use `utf8mb4` charset and `utf8mb4_unicode_ci` collation in `config.yml`, which is needed to migrate text that contains `emojis`.

`config.yml` example:

```yaml
mysql:
  database: mysql_database
  username: root
  password: root
  host: 127.0.0.1
  port: 3306
  charset: utf8mb4
  collation: utf8mb4_unicode_ci

postgresql:
  database: pg_database
  username: postgres
  host: 127.0.0.1
  port: 5432
  ssl_mode: disable
```