### PR TITLE
Use editorconfig for consistent indent between editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+; http://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This allows us to follow `Go` indentation standard without configuring our editors - as long as it supports `editorconfig`.  